### PR TITLE
OPT-78: Renaming setup key

### DIFF
--- a/libs/io/reader.py
+++ b/libs/io/reader.py
@@ -389,7 +389,7 @@ def create_specification_from_data(input_data: dict,
     Creates a specification object from a dict
     The model is in the form:
     {
-      "setup": [
+      "rooms": [
         {
           "type": "entrance",
           "variant": "s",
@@ -409,7 +409,7 @@ def create_specification_from_data(input_data: dict,
     }
     """
     specification = Specification(spec_name)
-    for item in input_data["setup"]:
+    for item in input_data["rooms"]:
         _category = item["type"]
         if _category not in SPACE_CATEGORIES:
             raise ValueError("Space type not present in space categories: {0}".format(_category))

--- a/resources/specifications/Levallois_A2-601_setup0.json
+++ b/resources/specifications/Levallois_A2-601_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/Levallois_A3-006_setup0.json
+++ b/resources/specifications/Levallois_A3-006_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/antony_A33_setup0.json
+++ b/resources/specifications/antony_A33_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/antony_B14_setup0.json
+++ b/resources/specifications/antony_B14_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/antony_B22_setup0.json
+++ b/resources/specifications/antony_B22_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/bagneux_A124_setup0.json
+++ b/resources/specifications/bagneux_A124_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/bagneux_B232_setup0.json
+++ b/resources/specifications/bagneux_B232_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/bussy_B002_setup0.json
+++ b/resources/specifications/bussy_B002_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/bussy_B104_setup0.json
+++ b/resources/specifications/bussy_B104_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/edison_10_setup0.json
+++ b/resources/specifications/edison_10_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/edison_20_setup0.json
+++ b/resources/specifications/edison_20_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/florent_setup0.json
+++ b/resources/specifications/florent_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_101_setup0.json
+++ b/resources/specifications/grenoble_101_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_102_setup0.json
+++ b/resources/specifications/grenoble_102_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_113_setup0.json
+++ b/resources/specifications/grenoble_113_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_114_setup0.json
+++ b/resources/specifications/grenoble_114_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_115_setup0.json
+++ b/resources/specifications/grenoble_115_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_121_setup0.json
+++ b/resources/specifications/grenoble_121_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_122_setup0.json
+++ b/resources/specifications/grenoble_122_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_125_setup0.json
+++ b/resources/specifications/grenoble_125_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_201_setup0.json
+++ b/resources/specifications/grenoble_201_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_211_setup0.json
+++ b/resources/specifications/grenoble_211_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/grenoble_212_setup0.json
+++ b/resources/specifications/grenoble_212_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT01_setup0.json
+++ b/resources/specifications/meurice_LT01_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT02_setup0.json
+++ b/resources/specifications/meurice_LT02_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT04_setup0.json
+++ b/resources/specifications/meurice_LT04_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT06_setup0.json
+++ b/resources/specifications/meurice_LT06_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT07_setup0.json
+++ b/resources/specifications/meurice_LT07_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT09_setup0.json
+++ b/resources/specifications/meurice_LT09_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT100_setup0.json
+++ b/resources/specifications/meurice_LT100_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_LT101_setup0.json
+++ b/resources/specifications/meurice_LT101_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_X.R0.01_setup0.json
+++ b/resources/specifications/meurice_X.R0.01_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/meurice_X.R0.05_setup0.json
+++ b/resources/specifications/meurice_X.R0.05_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/nantes-unile_B701_setup0.json
+++ b/resources/specifications/nantes-unile_B701_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris-mon18_A601_setup0.json
+++ b/resources/specifications/paris-mon18_A601_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris-mon18_A602_setup0.json
+++ b/resources/specifications/paris-mon18_A602_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris-mon18_A603_setup0.json
+++ b/resources/specifications/paris-mon18_A603_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris-mon18_A604_setup0.json
+++ b/resources/specifications/paris-mon18_A604_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris-mon18_A605_setup0.json
+++ b/resources/specifications/paris-mon18_A605_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris-mon18_A606_setup0.json
+++ b/resources/specifications/paris-mon18_A606_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris18_A402_setup0.json
+++ b/resources/specifications/paris18_A402_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/paris18_A501_setup0.json
+++ b/resources/specifications/paris18_A501_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_A001_setup0.json
+++ b/resources/specifications/saint-maur-faculte_A001_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_A102_setup0.json
+++ b/resources/specifications/saint-maur-faculte_A102_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_A103_setup0.json
+++ b/resources/specifications/saint-maur-faculte_A103_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_A104_setup0.json
+++ b/resources/specifications/saint-maur-faculte_A104_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_B001_setup0.json
+++ b/resources/specifications/saint-maur-faculte_B001_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_B002_setup0.json
+++ b/resources/specifications/saint-maur-faculte_B002_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_B011_setup0.json
+++ b/resources/specifications/saint-maur-faculte_B011_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_B112_setup0.json
+++ b/resources/specifications/saint-maur-faculte_B112_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_B121_setup0.json
+++ b/resources/specifications/saint-maur-faculte_B121_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-faculte_B153_setup0.json
+++ b/resources/specifications/saint-maur-faculte_B153_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H01_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H01_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H02_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H02_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H03_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H03_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H04_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H04_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H05_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H05_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H06_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H06_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H07_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H07_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/saint-maur-raspail_H08_setup0.json
+++ b/resources/specifications/saint-maur-raspail_H08_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/sartrouville_R1_setup0.json
+++ b/resources/specifications/sartrouville_R1_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],

--- a/resources/specifications/test_solution_duplex_setup.json
+++ b/resources/specifications/test_solution_duplex_setup.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "type": "entrance",
       "requiredArea": {

--- a/resources/specifications/test_space_planner_duplex_setup.json
+++ b/resources/specifications/test_space_planner_duplex_setup.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "type": "entrance",
       "requiredArea": {

--- a/resources/specifications/vernouillet_A002_setup0.json
+++ b/resources/specifications/vernouillet_A002_setup0.json
@@ -1,5 +1,5 @@
 {
-  "setup": [
+  "rooms": [
     {
       "linkedTo": [],
       "opensOn": [],


### PR DESCRIPTION
This will allow the new API format to be:
```js
{
  "lot": { ... },
  "setup": { 
    "rooms": [ ... ]
  }
}
```

This is to avoid having un clear APIs like:
```js
{
  "lot": { ... },
  "setup": { 
    "setup": [ ... ]
  }
}
```

Or create hard to non-evolutive API like:
```js
{
  "lot": { ... },
  "setup": [ ... ]
}
```
