### PR TITLE
Feature/excptioncirculationpath

### DIFF
--- a/libs/utils/graph.py
+++ b/libs/utils/graph.py
@@ -163,8 +163,9 @@ class EdgeGraph:
             try:
                 path = nx.shortest_path(self.graph_struct, "virtual1", "virtual2")[1:-1]
             except nx.exception.NetworkXNoPath:
-                # TODO : for now, the only case where this exception is thrown should when a floor
-                # is cut into several parts by a load bearing wall. This problem must be treated
+                # TODO : for now, the only case where this exception is thrown should be when
+                # a floor is cut into several parts by a load bearing wall.
+                # This problem must be treated
                 # possible treatment : by putting holes in the load bearing walls at location where
                 # they can be crossed
                 logging.warning('Graph_nx-no path found')


### PR DESCRIPTION
adding exception in case no path can be drawn between two spaces we try to connect
for now, the only case where this exception is thrown should be when a floor is cut into several parts by a load bearing wall.
This problem must be treated possible treatment : by putting holes in the load bearing walls at location where they can be crossed